### PR TITLE
perf: change prefetch strategy

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,4 +7,7 @@ export default defineConfig({
   output: 'hybrid',
   adapter: cloudflare(),
   site: 'https://santychuy.com',
+  prefetch: {
+    defaultStrategy: 'tap',
+  },
 });

--- a/src/components/pages/Blog/index.astro
+++ b/src/components/pages/Blog/index.astro
@@ -21,8 +21,6 @@ const res = await fetch(
 const data = await res.json();
 const views = data.results?.visitors.value;
 
-console.log(views);
-
 const title = post.title;
 const pubDate = post.pubDate;
 ---


### PR DESCRIPTION
With the purpose of not always prefetch a new page only hovering the link (that's the default behavior) now the link prefetch when the user taps the link