### PR TITLE
ci(hooks): add build step to pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,4 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 bun check
+bun run build
 bun test


### PR DESCRIPTION
# ci(hooks): add build step to pre-push hook

## Description

Adds `bun run build` to the pre-push git hook to catch build failures locally before pushing to remote. This prevents CI failures caused by build errors that pass type checking but fail during the actual build process.

## Related Issue

- N/A (small workflow improvement)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update
- [ ] Other (please specify)

## Screenshots (if applicable)

N/A

## Additional Notes

The pre-push hook now runs in this order:
1. `bun check` (Astro type check)
2. `bun run build` (Build the project) ← **NEW**
3. `bun test` (Run tests)

This ensures build validation happens locally before CI, reducing feedback loop time.